### PR TITLE
{HAX} msm8953-common: Sed thermal-engine to load from /vendor

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -93,4 +93,8 @@ if [ "$DEVICE" = "tissot" ]; then
     patchelf --set-soname libminikin-v27.so $DEVICE_BLOB_ROOT/lib/libminikin-v27.so
 fi
 
+# HAX for thermal-engine
+THERMAL_ENGINE = "$LINEAGE_ROOT"/vendor/"$VENDOR"/"$DEVICE"/proprietary/vendor/bin/thermal-engine
+sed -i "s|/system/etc/|/vendor/etc/|g" "THERMAL_ENGINE"
+
 "$MY_DIR"/setup-makefiles.sh


### PR DESCRIPTION
* It looks like thermal-engine is trying to load thermal-engine.conf
  from /system/vendor but we have it in /vendor which is causing
  thermal-engine to retry finding thermal-engine.conf.
* The solution is to sed the path in which thermal-engine loads
  thermal-engine.conf to /vendor to resolve any conflicts regarding
  loading the file